### PR TITLE
Add option to use custom fetch list

### DIFF
--- a/.fpm
+++ b/.fpm
@@ -1,7 +1,7 @@
 -s dir
 --name ffbir
 --license mit
---version 0.2.0
+--version 0.3.0
 --architecture all
 --description "Fetch all your fetches, but in rust"
 --url "https://github.com/underthefoxtree/ffbir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "ffbir"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffbir"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["underthefoxtree"]
 description = "fetch all your fetches, but in rust"

--- a/README.md
+++ b/README.md
@@ -10,66 +10,38 @@
 </div>
 </div>
 
-## 1 - Requirements
-`rust` - building ffbir
+## Installation
+You can either download the latest [release](https://github.com/underthefoxtree/ffbir/releases) or build from source (recommended).
 
-`fpm` (optional) - packaging the binary
+## Install from source (recommended)
 
-`just` (optional) - easy installation process
+### Requirements
+[`rust`](https://www.rust-lang.org/) - building ffbir
 
-## 2 - Install from Binary
-Just grab the latest [release](https://github.com/underthefoxtree/ffbir/releases)
+[`just`](https://github.com/casey/just) (optional) - easy installation process
 
-## 2 - Just Install (from source)
-Install using [just](https://github.com/casey/just)
+### Install with just
 ```bash
 $ just install
 ```
 
-## 2 - Other Install Options (from source)
-### 2.1 - Build
+### Install manually
 ```bash
+# Build
 $ cargo build --release
-```
-
-### 2.2 - Install
-There are multiple options for installation.
-#### Manual
-```bash
+# Install
 $ sudo cp target/release/ffbir /usr/bin
 ```
 
-#### Using Package Manager
-Build the package
-```bash
-# Red Hat based systems
-$ fpm -t rpm
+## Uninstall
+If installed using a binary from the [releases](https://github.com/underthefoxtree/ffbir/releases) page, use your package manager to uninstall.
 
-# Debian/Ubuntu based systems
-$ fpm -t deb
-
-# Arch based systems
-$ fpm -t pacman
-
-# Universal self-extracting script
-$ fpm -t sh
-```
-Install it using your package manager.
-
-## 3 - Just Uninstall
-ONLY use this if you installed using just.
+### Uninstall with just
 ```bash
 $ just uninstall
 ```
 
-## 3 - Other Uninstall Options
-#### Package Manager Installation
-Use this if you installed using fpm from source or from releases.
-
-Use your package manager to uninstall.
-
-#### Manual Installation
-Use this if you built and installed manually.
+### Uninstall manually
 ```bash
 $ sudo rm /usr/bin/ffbir
 ```

--- a/justfile
+++ b/justfile
@@ -2,29 +2,34 @@
 default:
     @just --list --unsorted
 
-alias b := build
-alias i := install
-alias u := uninstall
-
 # Build release version
 build: check-cargo
+    @echo "Building ffbir..."
     cargo build --release
 
 # Install manually
 install: build
-    sudo cp target/release/ffbir /usr/bin/
+    @echo "Installing..."
+    @sudo cp target/release/ffbir /usr/bin/ > /dev/null
+    @echo ""
+    @echo "Successfully installed ffbir into /usr/bin/"
 
 # Remove manual installation
 uninstall:
-    sudo rm /usr/bin/ffbir
+    @echo "Uninstalling..."
+    @sudo rm /usr/bin/ffbir > /dev/null
+    @echo ""
+    @echo "Successfully uninstalled."
 
 # Check if cargo is installed
 check-cargo:
-    which cargo
+    @which cargo > /dev/null
+    @echo "Cargo found."
 
 # Check if fpm is installed
 check-fpm:
-    which fpm
+    @which fpm > /dev/null
+    @echo "FPM found"
 
 # Package for all
 package-all:

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,24 +76,25 @@ fn main() {
             }
         }
         Some(path) => {
-            if !path.exists() {
-                println!("Fetches file not found!");
+            let lines = read_lines(path).unwrap_or_else(|error| {
+                eprintln!("Failed to read file: {}", error);
                 std::process::exit(1);
-            }
-            if let Ok(lines) = read_lines(path.as_path()) {
-                for line in lines {
-                    if let Ok(fetch) = line {
-                        if fetch_installed(&fetch) {
-                            println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
-                            fetch_count += 1;
-                        } else if !args.installed_only {
-                            println!(
-                                "{:>20} {}",
-                                fetch.on_cyan().black(),
-                                "is not installed".red()
-                            );
-                        }
-                    }
+            });
+            for line in lines {
+                let fetch = line.unwrap_or_else(|error| {
+                    eprintln!("Failed to read line: {}", error);
+                    std::process::exit(1);
+                });
+
+                if fetch_installed(&fetch) {
+                    println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
+                    fetch_count += 1;
+                } else if !args.installed_only {
+                    println!(
+                        "{:>20} {}",
+                        fetch.on_cyan().black(),
+                        "is not installed".red()
+                    );
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,42 +60,41 @@ fn main() {
 
     println!("{}\n", "### FetchFetch but in Rust ###".green().bold());
 
-    match args.fetches_file {
-        None => {
-            for fetch in &FETCHES {
-                if fetch_installed(fetch) {
-                    println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
-                    fetch_count += 1;
-                } else if !args.installed_only {
-                    println!(
-                        "{:>20} {}",
-                        fetch.on_cyan().black(),
-                        "is not installed".red()
-                    );
-                }
+    if args.fetches_file.is_none() {
+        for fetch in &FETCHES {
+            if fetch_installed(fetch) {
+                println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
+                fetch_count += 1;
+            } else if !args.installed_only {
+                println!(
+                    "{:>20} {}",
+                    fetch.on_cyan().black(),
+                    "is not installed".red()
+                );
             }
         }
-        Some(path) => {
-            let lines = read_lines(path).unwrap_or_else(|error| {
-                eprintln!("Failed to read file: {}", error);
+    } else {
+        let path = args.fetches_file.unwrap();
+
+        let lines = read_lines(path).unwrap_or_else(|error| {
+            eprintln!("Failed to read file: {}", error);
+            std::process::exit(1);
+        });
+        for line in lines {
+            let fetch = line.unwrap_or_else(|error| {
+                eprintln!("Failed to read line: {}", error);
                 std::process::exit(1);
             });
-            for line in lines {
-                let fetch = line.unwrap_or_else(|error| {
-                    eprintln!("Failed to read line: {}", error);
-                    std::process::exit(1);
-                });
 
-                if fetch_installed(&fetch) {
-                    println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
-                    fetch_count += 1;
-                } else if !args.installed_only {
-                    println!(
-                        "{:>20} {}",
-                        fetch.on_cyan().black(),
-                        "is not installed".red()
-                    );
-                }
+            if fetch_installed(&fetch) {
+                println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
+                fetch_count += 1;
+            } else if !args.installed_only {
+                println!(
+                    "{:>20} {}",
+                    fetch.on_cyan().black(),
+                    "is not installed".red()
+                );
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,11 @@
-use which::which;
-use colored::Colorize;
+use std::fs::File;
+use std::io::{self, BufRead};
+use std::path::Path;
+use std::path::PathBuf;
+
 use clap::Parser;
+use colored::Colorize;
+use which::which;
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -8,10 +13,21 @@ struct Cli {
     /// Show only installed fetches
     #[clap(long = "installed-only", short = 'i', action)]
     installed_only: bool,
+
+    #[clap(long = "fetches", short = 'f')]
+    fetches_file: Option<PathBuf>,
 }
 
 fn fetch_installed(fetch: &str) -> bool {
     which(fetch).is_ok()
+}
+
+fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(filename)?;
+    Ok(io::BufReader::new(file).lines())
 }
 
 fn main() {
@@ -44,14 +60,42 @@ fn main() {
 
     println!("{}\n", "### FetchFetch but in Rust ###".green().bold());
 
-    for fetch in &FETCHES {
-
-        if fetch_installed(fetch) {
-            println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
-            fetch_count += 1;
+    match args.fetches_file {
+        None => {
+            for fetch in &FETCHES {
+                if fetch_installed(fetch) {
+                    println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
+                    fetch_count += 1;
+                } else if !args.installed_only {
+                    println!(
+                        "{:>20} {}",
+                        fetch.on_cyan().black(),
+                        "is not installed".red()
+                    );
+                }
+            }
         }
-        else if !args.installed_only {
-            println!("{:>20} {}", fetch.on_cyan().black(), "is not installed".red());
+        Some(path) => {
+            if !path.exists() {
+                println!("Fetches file not found!");
+                std::process::exit(1);
+            }
+            if let Ok(lines) = read_lines(path.as_path()) {
+                for line in lines {
+                    if let Ok(fetch) = line {
+                        if fetch_installed(&fetch) {
+                            println!("{:>20} {}", fetch.on_cyan().black(), "is installed".green());
+                            fetch_count += 1;
+                        } else if !args.installed_only {
+                            println!(
+                                "{:>20} {}",
+                                fetch.on_cyan().black(),
+                                "is not installed".red()
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Adds the option to specify a text file to use instead of the default fetch list.
The text file must have one fetch per line, without any additional characters.

Also cleaned up the justfile and prettified the output.